### PR TITLE
Fix Chef::Exceptions::ImmutableAttributeModification

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,8 +28,7 @@ require 'chef/util/file_edit'
 
 fqdn = node[:set_fqdn]
 if fqdn
-  fqdn =~ /^([^.]+)/
-  hostname = $1
+  hostname = fqdn
   changed = false
 
   file '/etc/hostname' do


### PR DESCRIPTION
> Node attributes are read-only when you do not specify which precedence level to set. To set an attribute use code like `node.default["key"] = "value"'

Do exactly that to make this cookbook work on chef 11.0.0
