### PR TITLE
Add name to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "hostname"
 maintainer       "Maciej Pasternacki"
 maintainer_email "maciej@pasternacki.net"
 license          "MIT"


### PR DESCRIPTION
For [Berkshelf](http://berkshelf.com/), the name in metadata.rb should be explicitly specified.
