### PR TITLE
apply hostname changes immediately rather than at the end of chef run

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,12 +33,12 @@ if fqdn
   file '/etc/hostname' do
     content "#{hostname}\n"
     mode "0644"
-    notifies :reload, "ohai[reload]"
+    notifies :reload, "ohai[reload]", :immediate
   end
 
   execute "hostname #{hostname}" do
     only_if { node['hostname'] != hostname }
-    notifies :reload, "ohai[reload]"
+    notifies :reload, "ohai[reload]", :immediate
   end
 
   hostsfile_entry "localhost" do
@@ -52,7 +52,7 @@ if fqdn
     hostname fqdn
     aliases [ hostname ]
     action :create
-    notifies :reload, "ohai[reload]"
+    notifies :reload, "ohai[reload]", :immediate
   end
 
   ohai "reload" do


### PR DESCRIPTION
Currently if the hostname is changed the changes are caught by Chef only in the delayed notification phase thus affecting nothing.

This commit should fix the issue.
