### PR TITLE
Allow hosts file to be updated with the ip address of the node

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ and have node set its FQDN and hostname based on its chef node name
 - `node['hostname_cookbook']['hostsfile_ip']` -- IP used in
   `/etc/hosts` to correctly set FQDN (default: `127.0.1.1`)
 
+node['hostname_cookbook']['hostsfile_ip'] can be set to `ipaddress` to pick up the ip address of the node.
 
 ## Recipes
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,8 +61,13 @@ if fqdn
     action :append
   end
 
+  ipaddress = node['hostname_cookbook']['hostsfile_ip']
+  if ipaddress == 'ipaddress'
+    ipaddress = node['ipaddress']
+  end
+
   hostsfile_entry 'set hostname' do
-    ip_address node['hostname_cookbook']['hostsfile_ip']
+    ip_address ipaddress 
     hostname fqdn
     aliases [hostname]
     action :create

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,12 +62,10 @@ if fqdn
   end
 
   ipaddress = node['hostname_cookbook']['hostsfile_ip']
-  if ipaddress == 'ipaddress'
-    ipaddress = node['ipaddress']
-  end
+  ipaddress = node['ipaddress'] if ipaddress == 'ipaddress'
 
   hostsfile_entry 'set hostname' do
-    ip_address ipaddress 
+    ip_address ipaddress
     hostname fqdn
     aliases [hostname]
     action :create


### PR DESCRIPTION
Using a static IP address in the hosts file interferes with DNS server entries (as they differ). This causes issue when trying to use hadoop hdfs.

Added the ability to use the node ip address.