### PR TITLE
Allow attribute used in wildcard FQDN to be customized

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ and have node set its FQDN and hostname based on its chef node name
 - `node['hostname_cookbook']['hostsfile_ip']` -- IP used in
   `/etc/hosts` to correctly set FQDN (default: `127.0.1.1`)
 
+- `node['hostname_cookbook']['attribute_to_sub']` -- attribute used
+  to subsitute into a wildcard `set_fqdn` value (default: `name`)
+
 
 ## Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 default['hostname_cookbook']['hostsfile_ip'] = '127.0.1.1'
+default['hostname_cookbook']['attribute_to_sub'] = 'name'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,7 +27,7 @@
 
 fqdn = node['set_fqdn']
 if fqdn
-  fqdn = fqdn.sub('*', node.name)
+  fqdn = fqdn.sub('*', node[node['hostname_cookbook']['attribute_to_sub']])
   fqdn =~ /^([^.]+)/
   hostname = Regexp.last_match[1]
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -6,6 +6,7 @@ describe 'hostname::default' do
   let(:chef_run) { ChefSpec::Runner.new }
 
   it 'sets FQDN' do
+    chef_run.node.set['name'] = 'foobar'
     chef_run.node.set['set_fqdn'] = 'test.example.com'
     chef_run.converge 'hostname'
 
@@ -14,7 +15,7 @@ describe 'hostname::default' do
   end
 
   it "substitutes star to node's name" do
-    chef_run.node.name 'test'
+    chef_run.node.set['name'] = 'test'
     chef_run.node.set['set_fqdn'] = '*.example.com'
     chef_run.converge 'hostname'
 


### PR DESCRIPTION
In Ubuntu 14.04 `node.name` is returning the FQND, so every time you ran chef the FQND would grow:

```
set_fqnd => "*.bar.com"

Run #1: foo.bar.com
Run #2: foo.bar.com.bar.com
Run #3: foo.bar.com.bar.com.bar.com
```

This lets you use `hostname` which gives you the correct value to sub.