### PR TITLE
Refactor to reduce reload restarts of services and ohai

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -77,11 +77,13 @@ if fqdn
     ruby_block "Update #{sysctl}" do
       block do
         file = Chef::Util::FileEdit.new(sysctl)
+        file.search_file_delete_line("kernel.hostname=.*")
         file.insert_line_if_no_match("kernel.hostname=#{hostname}", \
                                      "kernel.hostname=#{hostname}")
         file.write_file
       end
       not_if { open(hostfile).grep(/kernel.hostname=#{hostname}/).any? }
+      notifies :reload, "execute[hostname #{hostname}]", :immediately
     end
   else
     file '/etc/hostname' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -83,7 +83,7 @@ if fqdn
         file.write_file
       end
       not_if { open(hostfile).grep(/kernel.hostname=#{hostname}/).any? }
-      notifies :reload, "execute[hostname #{hostname}]", :immediately
+      notifies :run, "execute[hostname #{hostname}]", :immediately
     end
   else
     file '/etc/hostname' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,11 +37,15 @@ if fqdn
       mode '0755'
     end
 
+    service 'netif' do
+      action :nothing
+      supports [:enable,:reload]
+    end
+
     rc_conf_lines = ["hostname=#{fqdn}\n"]
     if node['hostname_cookbook']['hostsfile_ip_interface']
       rc_conf_lines <<
         "ifconfig_#{node['hostname_cookbook']['hostsfile_ip_interface']}_alias=\"inet #{node['hostname_cookbook']['hostsfile_ip']}/32\"\n"
-      service 'netif'
     end
 
     file '/etc/rc.conf.d/hostname' do
@@ -51,12 +55,13 @@ if fqdn
         if node['hostname_cookbook']['hostsfile_ip_interface']
     end
 
-    execute "hostname #{fqdn}" do
-      only_if { node['fqdn'] != fqdn }
-      notifies :reload, 'ohai[reload]', :immediately
+  when 'centos', 'redhat', 'amazon', 'scientific'
+    service 'network' do
+      action :nothing
+      supports [:enable,:reload]
+      subscribes :reload, "hostname #{hostname}", :immediately
     end
 
-  when 'centos', 'redhat', 'amazon', 'scientific'
     hostfile = '/etc/sysconfig/network'
     ruby_block "Update #{hostfile}" do
       block do
@@ -64,8 +69,9 @@ if fqdn
         file.search_file_replace_line('^HOSTNAME', "HOSTNAME=#{fqdn}")
         file.write_file
       end
-      notifies :reload, 'ohai[reload]', :immediately
+      not_if { open(hostfile).grep(/HOSTNAME=#{fqdn}/).any? }
     end
+    
     # this is to persist the correct hostname after machine reboot
     sysctl = '/etc/sysctl.conf'
     ruby_block "Update #{sysctl}" do
@@ -75,27 +81,18 @@ if fqdn
                                      "kernel.hostname=#{hostname}")
         file.write_file
       end
-      notifies :reload, 'ohai[reload]', :immediately
+      not_if { open(hostfile).grep(/kernel.hostname=#{hostname}/).any? }
     end
-    execute "hostname #{hostname}" do
-      only_if { node['hostname'] != hostname }
-      notifies :reload, 'ohai[reload]', :immediately
-    end
-    service 'network' do
-      action :restart
-    end
-
   else
     file '/etc/hostname' do
       content "#{hostname}\n"
       mode '0644'
-      notifies :reload, 'ohai[reload]', :immediately
     end
-
-    execute "hostname #{hostname}" do
-      only_if { node['hostname'] != hostname }
-      notifies :reload, 'ohai[reload]', :immediately
-    end
+  end
+    
+  execute "hostname #{hostname}" do
+    only_if { node['hostname'] != hostname }
+    notifies :reload, 'ohai[reload]', :immediately
   end
 
   hostsfile_entry 'localhost' do
@@ -109,7 +106,6 @@ if fqdn
     hostname fqdn
     aliases [hostname]
     action :create
-    notifies :reload, 'ohai[reload]', :immediately
   end
 
   ohai 'reload' do
@@ -120,3 +116,4 @@ else
     level :warn
   end
 end
+


### PR DESCRIPTION
This PR refactors default.rb for FreeBsd, Debian and RHEL to ensure that we don't needlessly call restart on services or reload on Ohai. 

Tested on a Centos 6.5 box. 