### PR TITLE
Set unique hosts file entry for hostname

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -107,6 +107,7 @@ if fqdn
     ip_address node['hostname_cookbook']['hostsfile_ip']
     hostname fqdn
     aliases [hostname]
+    unique true
     action :create
     notifies :reload, 'ohai[reload_hostname]', :immediately
   end


### PR DESCRIPTION
So in https://github.com/3ofcoins/chef-cookbook-hostname/blob/develop/recipes/default.rb#L106-L112 the hosts file entry is created for the hostname, however the `unique` parameter is not specified, so if the IP of the host has changed, a duplicate entry will be added for the hostname, resulting in all sorts of nasty funkiness.

This PR adds the `unique` param.