### PR TITLE
Ensure sysctl kernel.hostname set correctly

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -76,10 +76,13 @@ if fqdn
     sysctl = '/etc/sysctl.conf'
     file sysctl do
       action :create
+      regex = /^kernel\.hostname=.*/
+      newline = "kernel.hostname=#{hostname}"
       content lazy {
-        ::IO.read(sysctl) + "kernel.hostname=#{hostname}\n"
+        original = ::IO.read(sysctl)
+        original.match(regex) ? original.gsub(regex, newline) : original + newline
       }
-      not_if { ::IO.read(sysctl) =~ /^kernel\.hostname=#{hostname}$/ }
+      not_if { ::IO.read(sysctl).scan(regex).last == newline }
       notifies :reload, 'ohai[reload_hostname]', :immediately
       notifies :restart, 'service[network]', :delayed
     end


### PR DESCRIPTION
Code to set kernel.hostname in /etc/sysctl.conf didn't allow for a
temporary change of hostname that is later reverted. For example, if
the hostname is originally set to foo.example.com, is then changed to
bar.example.com and later reverted to foo.example.com, the last
kernel.hostname entry in /etc/sysctl.conf will remain bar.example.com,
because the guard condition looks for any match in /etc/sysctl.conf

Fixed by editing existing entries where applicable and updating the
guard condition to find and match on the last kernel.hostname line
