### PR TITLE
reorder vagrant gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem 'rake'
 gem 'rubocop'
 
 group :integration do
-  gem 'test-kitchen'
   gem 'kitchen-vagrant'
+  gem 'test-kitchen'
 end


### PR DESCRIPTION
```
Gemfile:12:3: C: Bundler/OrderedGems: Gem kitchen-vagrant should appear before test-kitchen in their gem group.
  gem 'kitchen-vagrant'
  ^^^^^^^^^^^^^^^^^^^^^
13 files inspected, 1 offense detected
RuboCop failed!
```